### PR TITLE
made possible to override the stream name on EventStoreRepository

### DIFF
--- a/event-sourcing-core/src/main/kotlin/br/com/zup/eventsourcing/core/AggregateRoot.kt
+++ b/event-sourcing-core/src/main/kotlin/br/com/zup/eventsourcing/core/AggregateRoot.kt
@@ -66,8 +66,7 @@ open class AggregateId(val value: String) {
         return true
     }
 
-    override fun hashCode(): Int {
-        return value.hashCode()
-    }
+    override fun hashCode(): Int = value.hashCode()
+    override fun toString(): String = value
 }
 

--- a/event-sourcing-core/src/main/kotlin/br/com/zup/eventsourcing/core/Repository.kt
+++ b/event-sourcing-core/src/main/kotlin/br/com/zup/eventsourcing/core/Repository.kt
@@ -8,15 +8,15 @@ abstract class Repository<T : AggregateRoot> {
     abstract fun get(aggregateId: AggregateId): T
     abstract fun getLastMetaData(aggregateId: AggregateId): MetaData
 
-    protected fun getGenericName(): String {
-        return ((javaClass
-                .genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<T>).simpleName
-    }
 
-    protected fun getGenericCanonicalName(): String {
-        return ((javaClass
-                .genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<T>).canonicalName
-    }
+    protected fun getGenericClass(): Class<T> =
+            (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<T>
+
+    protected fun getGenericName(): String =
+            getGenericClass().simpleName
+
+    protected fun getGenericCanonicalName(): String =
+            getGenericClass().canonicalName
 
     class NotFoundException : Throwable()
 

--- a/event-store-connector/src/test/kotlin/br/com/zup/eventsourcing/eventstore/OverrideStreamNameTest.kt
+++ b/event-store-connector/src/test/kotlin/br/com/zup/eventsourcing/eventstore/OverrideStreamNameTest.kt
@@ -1,0 +1,59 @@
+package br.com.zup.eventsourcing.eventstore
+
+import br.com.zup.eventsourcing.core.AggregateId
+import br.com.zup.eventsourcing.eventstore.config.BaseTest
+import br.com.zup.eventsourcing.eventstore.domain.MyAggregateRoot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.util.*
+
+class OverrideStreamNameTest : BaseTest() {
+
+    @Service
+    open class MyAggregateRepositoryWithOverloadedStreamName : EventStoreRepository<MyAggregateRoot>(){
+        override fun getStreamName(aggregateId: AggregateId): String = "Test-$aggregateId"
+    }
+
+    @Autowired
+    lateinit var myAggregateRepository: MyAggregateRepositoryWithOverloadedStreamName
+
+    @Test
+    fun saveMyAggregate_WithoutMetaData() {
+        val id = UUID.randomUUID()
+        val myAggregate = MyAggregateRoot(AggregateId(id))
+        myAggregateRepository.save(myAggregate)
+        assertEquals(1, myAggregate.events.size)
+    }
+
+    @Test
+    fun saveMyAggregateCreateAndGet() {
+        val id = UUID.randomUUID()
+        val myAggregate = MyAggregateRoot(AggregateId(id))
+        myAggregateRepository.save(myAggregate)
+        val myAggregateGot = myAggregateRepository.get(myAggregate.id)
+        assertEquals(myAggregate, myAggregateGot)
+        assertEquals(1, myAggregate.events.size)
+        assertEquals(0, myAggregateGot.events.size)
+    }
+
+    @Test
+    fun createAndModifyAggregate() {
+        val id = UUID.randomUUID()
+
+        val myAggregate = MyAggregateRoot(AggregateId(id))
+        myAggregate.modify()
+        myAggregate.modify()
+        myAggregateRepository.save(myAggregate)
+
+        val loadedFromEventStore = myAggregateRepository.get(myAggregate.id)
+
+        assertEquals(myAggregate, loadedFromEventStore)
+        assertEquals("ModifyEvent", loadedFromEventStore.status)
+        assertEquals(2, loadedFromEventStore.modificationHistory.size)
+        assertEquals(2, loadedFromEventStore.version.value)
+        assertEquals(3, myAggregate.events.size)
+        assertEquals(0, loadedFromEventStore.events.size)
+    }
+}

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cd /home/application/
-./wait-for-it.sh "event-store:2113" -- echo "event-store 2113 is up"
+./wait-for-it.sh "event-store:2113" -- echo "event-store 2113 is up" && sleep 5
 curl --request POST  --url  'http://event-store:2113/projections/continuous?name=gather-myaggregateroot%26type=js%26enabled=true%26emit=true%26trackemittedstreams=true' --header 'authorization: Basic YWRtaW46Y2hhbmdlaXQ=' --data-binary "@resources/gather-aggregate.js"
 curl --request PUT  --url  'http://event-store:2113/subscriptions/MyAggregateRoot/MyAggregateRootSubscriptionGroup' --header 'authorization: Basic YWRtaW46Y2hhbmdlaXQ=' --header 'content-type: application/json' --data-binary "@resources/my-aggregate-subscription-group.json"
 curl --request POST  --url 'http://event-store:2113/projection/$by_category/command/enable' --header 'authorization: Basic YWRtaW46Y2hhbmdlaXQ=' --data '{}'


### PR DESCRIPTION
Previous behaviour was maintained: class simple name + aggregateId.
If you want to change the stream name just override the getStreamName(aggregateId) method.